### PR TITLE
Don't require jQuery

### DIFF
--- a/lib/assets/javascripts/ios-checkboxes.js.coffee
+++ b/lib/assets/javascripts/ios-checkboxes.js.coffee
@@ -1,2 +1,1 @@
-#= require jquery
 #= require ios-checkboxes/ios-checkboxes


### PR DESCRIPTION
I understand it's built on jQuery and so it has a jQuery dependency. In case there's any confusion, I'm not advocating changing that.

Instead, I'm suggesting that `ios-checkboxes` should not explicitly require jQuery in the manifest file (i.e. `lib/assets/javascripts/ios-checkboxes.js.coffee`). In all likelihood, anyone using this gem will already have required jQuery elsewhere in their project, and so re-requiring it is at best unnecessary and at worst can cause problems. In my case, it was causing name collision issues.

I just removed that one line and all the tests seemed to pass just fine.

Thanks for this gem!
