### PR TITLE
Ported $.browser fix

### DIFF
--- a/lib/assets/javascripts/ios-checkboxes/ios-checkboxes.js.coffee
+++ b/lib/assets/javascripts/ios-checkboxes/ios-checkboxes.js.coffee
@@ -1,6 +1,35 @@
 # iPhone-style Checkboxes Coffee plugin
 # Copyright Thomas Reynolds, licensed GPL & MIT
 
+unless $.browser?
+  userAgent = navigator.userAgent || ""
+
+  jQuery.uaMatch = (ua) ->
+    ua = ua.toLowerCase()
+
+    match = /(chrome)[ \/]([\w.]+)/.exec( ua ) ||
+      /(webkit)[ \/]([\w.]+)/.exec( ua ) ||
+      /(opera)(?:.*version)?[ \/]([\w.]+)/.exec( ua ) ||
+      /(msie) ([\w.]+)/.exec( ua ) ||
+      ua.indexOf("compatible") < 0 && /(mozilla)(?:.*? rv:([\w.]+))?/.exec( ua ) ||
+      []
+
+    return {
+      browser: match[ 1 ] || "",
+      version: match[ 2 ] || "0"
+    }
+
+  matched = jQuery.uaMatch( userAgent )
+
+  jQuery.browser = {}
+
+  if matched.browser
+    jQuery.browser[ matched.browser ] = true
+    jQuery.browser.version = matched.version
+
+  if jQuery.browser.webkit
+    jQuery.browser.safari = true
+
 class iOSCheckbox
   constructor: (elem, options) ->
     @elem = $(elem)


### PR DESCRIPTION
jQuery 1.9 removed $.browser. I just copied the coffee file from the main repo and it fixes the gem for apps using 1.9.
